### PR TITLE
Alternate docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 composer.lock
 config.inc
 npm-debug.log
+docker-compose.override.yml
 
 # Exclude all fonts that's not placed inside a folder (vendor fonts).
 fonts/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  npm:
+    build: docker/npm
+    volumes:
+      - '.:/data'
+  timelord:
+    build: .
+    volumes:
+      - '.:/var/www/html'

--- a/docker/npm/Dockerfile
+++ b/docker/npm/Dockerfile
@@ -1,0 +1,12 @@
+FROM digitallyseamless/nodejs-bower-grunt
+
+RUN apt-get update && \
+  apt-get install -y \
+  ruby \
+  ruby-dev
+
+RUN gem install --no-rdoc --no-ri sass -v 3.4.22
+RUN gem install --no-rdoc --no-ri compass
+
+COPY entrypoint.sh /
+ENTRYPOINT "/entrypoint.sh"

--- a/docker/npm/entrypoint.sh
+++ b/docker/npm/entrypoint.sh
@@ -1,0 +1,3 @@
+/usr/local/bin/npm install
+/usr/local/bin/bower install
+/usr/local/bin/grunt


### PR DESCRIPTION
This setup is a little more automated than the current (npm install & bower install run automatically).
It also seems to depend on `watch` in grunt, which does not work properly for me (can't exit the container running grunt cleanly).

Needs a bit of debugging + merging.