### PR TITLE
Fix Content-Type header and output for error responses

### DIFF
--- a/inc/feed.php
+++ b/inc/feed.php
@@ -31,17 +31,22 @@
 
   // Wrap response.
   function get_contents($url) {
-    $header = get_headers($url);
-    preg_match('!\d{3}!', $header[0], $matches);
+    $headers = get_headers($url, TRUE);
+    preg_match('!\d{3}!', $headers[0], $matches);
     $code = (int) reset($matches);
 
-    if ($code === 200) {
-      return file_get_contents($url);
+    if (isset($headers['Content-Type'])) {
+      header('Content-Type: ' . $headers['Content-Type']);
     }
 
-    return http_response_code($code);
+    if ($code !== 200) {
+      # Set HTTP response according to remote.
+      http_response_code($code);
+    }
+    else {
+      return file_get_contents($url);
+    }
   }
 
   // Output result.
   print get_contents($url);
-

--- a/inc/feed.php
+++ b/inc/feed.php
@@ -32,6 +32,7 @@
   // Wrap response.
   function get_contents($url) {
     $headers = get_headers($url, TRUE);
+    // Fetch HTTP response code from header.
     preg_match('!\d{3}!', $headers[0], $matches);
     $code = (int) reset($matches);
 
@@ -40,7 +41,7 @@
     }
 
     if ($code !== 200) {
-      # Set HTTP response according to remote.
+      // Set HTTP response according to remote.
       http_response_code($code);
     }
     else {


### PR DESCRIPTION
Two fixes here:
1. When the Timelord feed fetched content from Harvester, and Harvester returned a non-200 response, Timelord was outputting the *previous* HTTP response (200) to the browser, due to how `http_response_code()` works. It now outputs nothing to the browser in that case.
2. The Timelord feed didn't output the same Content-Type header as the Harvester content (usually JSON), even though the content was JSON syntax. This is also fixed here.