### PR TITLE
Removed default release tag in helm

### DIFF
--- a/helm-chart/timelord/values.yaml
+++ b/helm-chart/timelord/values.yaml
@@ -1,7 +1,7 @@
 # The image tag is added in the github workflow based on which tag the developer pushes to main
 image: ghcr.io/reload/timelord
 # The tag should be overriden during 'helm upgrade' operations with --set.
-imageTag: latest
+#imageTag: latest
 
 ingress:
   host: timelord.reload.dk


### PR DESCRIPTION
Achton enabled by mistake, but it serves as an example.

Non-breaking change -- leaves helm with no default in case $RELEASE_TAG is omitted from github workflow file.